### PR TITLE
Keep traceback in tx2as

### DIFF
--- a/tools/tx/tx2as.py
+++ b/tools/tx/tx2as.py
@@ -173,7 +173,7 @@ for _, _, files in os.walk(translations_dir + dir_name):
         except ElementTree.ParseError as error:
             print("shit happens with " + currentFilePath)
             print(error)
-            raise error
+            raise
 
 pprint.pprint(totalCounter)
 for locale_code, text in changelog.items():


### PR DESCRIPTION
The code around line 176 in tools/tx/tx2as.py looked like it might have an issue. It re-raises the caught exception object and loses the cleaner traceback shape. this patch changes that to a plain raise so the original stack stays intact.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.